### PR TITLE
Initial example of generating Prometheus SDK metrics from Otel semconv with the weaver tool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,17 @@ $(BUF):
 MDOX = mdox
 $(MDOX):
 	@go install github.com/bwplotka/mdox@latest
+
+# Hacky, replace the binary path for yourself for now.
+# One could use docker as well. TODO: Fix this.
+WEAVER = ../otel-weaver/target/debug/weaver
+
 # ------
 
 .PHONY: help
 help: ## Display this help and any documented user-facing targets. Other undocumented targets may be present in the Makefile.
 help:
 	@awk 'BEGIN {FS = ": ##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/%]+: ##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
-
 
 .PHONY: docker
 docker:
@@ -48,4 +52,14 @@ format: $(GOFUMPT) $(GOIMPORTS) $(MDOX)
 	@$(GOFUMPT) -extra -w $(GO_FILES)
 	@echo ">> format documentation"
 	@$(MDOX) fmt --soft-wraps ./*.md
+
+SEMCONV_VERSION ?= v0.1.0
+.PHONY: gen # Generate artefacts e.g. metric definitions from my-org semconv.
+gen:
+	@echo ">> weaver generate"
+	@$(WEAVER) registry generate \
+		--registry=./my-org/semconv/$(SEMCONV_VERSION) \
+		--templates=./client_golang/semconv \
+		go \
+		./go/my-app/semconv/$(SEMCONV_VERSION)
 

--- a/client_golang/semconv/registry/go/metric.go.j2
+++ b/client_golang/semconv/registry/go/metric.go.j2
@@ -1,0 +1,87 @@
+{%- set my_file_name = ctx.metric_name | lower | snake_case ~ ".go" -%}
+{{- template.set_file_name(my_file_name) -}}
+{% set construct_name = ctx.id.split('.')[-1] %}
+{%- set instrToVecTypes = {
+ 	'counter': "CounterVec",
+  'gauge': "GaugeVec",
+}-%}
+{%- set instrToOptTypes = {
+ 	'counter': "CounterOpts",
+	'gauge': "GaugeOpts",
+}-%}
+{%- set labelTypeToTypes = {
+	'string': "string",
+ 	'int': "int",
+	'double': "float64",
+}-%}
+{% macro const_label_type(label) -%}
+{{ construct_name | pascal_case ~ label.tag | pascal_case }}
+{%- endmacro %}
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv // TODO(bwplotka): Use id prefix or something more unique?
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+{%- for label in ctx.attributes -%}
+	{%- if label.type.members is defined %}
+
+type {{ const_label_type(label) }} string
+
+const (
+	{%- for value in label.type.members %}
+		{{ value.id | pascal_case }}{{ const_label_type(label) }} {{ const_label_type(label) }} = "{{ value.value }}"
+	{%- endfor %}
+)
+	{%- endif %}
+{%- endfor %}
+
+func MustNew{{ construct_name | pascal_case }}{{ ctx.instrument | pascal_case }}Vec(reg prometheus.Registerer) *prometheus.{{ instrToVecTypes[ctx.instrument] }} {
+	return promauto.With(reg).New{{ instrToVecTypes[ctx.instrument] }}(prometheus.{{ instrToOptTypes[ctx.instrument] }}{
+		Name: "{{ ctx.metric_name }}",
+		{% if ctx.note is defined -%}
+		Help: "{{ ctx.note }}",
+		{% else -%}
+		Help: "{{ ctx.brief }}",
+		{%- endif %}
+		// Unit: "{{ ctx.unit }}" // TODO(bwplotka): Add Unit as one of the supported options.
+	}, []string{
+{%- for label in ctx.attributes %}
+		"{{label.tag}}",
+{%- endfor %}
+	})
+}
+
+/*
+TODO(bwplotka): Add more type safety e.g. for CustomElementsCounterVec:
+
+type CustomElementsCounterVec struct {
+	prometheus.CounterVec
+}
+
+func (v *CustomElementsCounterVec) WithLabelValues(integer int, category CustomElementsCategory, fraction float64) prometheus.Counter {
+	// This is not ideal as we do, potentially expensive stringifying on the hot path.
+  // Fix might require internals to completely differ in the client_golang for the efficient solution.
+	return v.CounterVec.WithLabelValues(fmt.Sprintf("%v", integer), string(category), fmt.Sprintf("%v", fraction))
+}
+*/
+
+
+
+

--- a/client_golang/semconv/registry/go/weaver.yaml
+++ b/client_golang/semconv/registry/go/weaver.yaml
@@ -1,0 +1,17 @@
+templates:
+- template: metric.go.j2
+  filter: >
+    .groups
+    | map(select(.type == "metric"))
+    | sort_by(.metric_name)
+  application_mode: each
+
+comment_formats:
+  go:
+    format: markdown
+    prefix: "// "
+    indent_first_level_list_items: true
+    shortcut_reference_link: true
+    trim: true
+    remove_trailing_dots: true
+default_comment_format: go

--- a/go/my-app/manual.go
+++ b/go/my-app/manual.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+func mustNewCustomStableMetric(reg prometheus.Registerer) *prometheus.CounterVec {
+	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "my_app_custom_elements_total",
+		Help: "Custom counter metric for my app counting important elements. It serves as an example " +
+				"of a very important metric that everyone is using.",
+	}, []string{"integer", "category", "fraction"})
+}

--- a/go/my-app/semconv/v0.1.0/my_app_custom_elements_total.go
+++ b/go/my-app/semconv/v0.1.0/my_app_custom_elements_total.go
@@ -1,0 +1,59 @@
+
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv // TODO(bwplotka): Use id prefix or something more unique?
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type CustomElementsCategory string
+
+const (
+		ACustomElementsCategory CustomElementsCategory = "a"
+		BCustomElementsCategory CustomElementsCategory = "b"
+		OtherCustomElementsCategory CustomElementsCategory = "other"
+)
+
+func MustNewCustomElementsCounterVec(reg prometheus.Registerer) *prometheus.CounterVec {
+	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "my_app_custom_elements_total",
+		Help: "Custom counter metric for my app counting important elements. It serves as an example of a very important metric that everyone is using.",
+		// Unit: "elements" // TODO(bwplotka): Add Unit as one of the supported options.
+	}, []string{
+		"integer",
+		"category",
+		"fraction",
+	})
+}
+
+/*
+TODO(bwplotka): Add more type safety e.g. for CustomElementsCounterVec:
+
+type CustomElementsCounterVec struct {
+	prometheus.CounterVec
+}
+
+func (v *CustomElementsCounterVec) WithLabelValues(integer int, category CustomElementsCategory, fraction float64) prometheus.Counter {
+	// This is not ideal as we do, potentially expensive stringifying on the hot path.
+  // Fix might require internals to completely differ in the client_golang for the efficient solution.
+	return v.CounterVec.WithLabelValues(fmt.Sprintf("%v", integer), string(category), fmt.Sprintf("%v", fraction))
+}
+*/
+
+
+

--- a/go/my-app/semconv/v0.1.0/my_app_custom_elements_total.go
+++ b/go/my-app/semconv/v0.1.0/my_app_custom_elements_total.go
@@ -33,7 +33,7 @@ func MustNewCustomElementsCounterVec(reg prometheus.Registerer) *prometheus.Coun
 	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "my_app_custom_elements_total",
 		Help: "Custom counter metric for my app counting important elements. It serves as an example of a very important metric that everyone is using.",
-		// Unit: "elements" // TODO(bwplotka): Add Unit as one of the supported options.
+		// Unit: "{elements}" // TODO(bwplotka): Add Unit as one of the supported options.
 	}, []string{
 		"integer",
 		"category",

--- a/go/my-app/semconv/v0.1.0/my_app_some_elements_total.go
+++ b/go/my-app/semconv/v0.1.0/my_app_some_elements_total.go
@@ -25,7 +25,7 @@ func MustNewSomeElementsCounterVec(reg prometheus.Registerer) *prometheus.Counte
 	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "my_app_some_elements_total",
 		Help: "old metric",
-		// Unit: "unknown" // TODO(bwplotka): Add Unit as one of the supported options.
+		// Unit: "{unknown}" // TODO(bwplotka): Add Unit as one of the supported options.
 	}, []string{
 	})
 }

--- a/go/my-app/semconv/v0.1.0/my_app_some_elements_total.go
+++ b/go/my-app/semconv/v0.1.0/my_app_some_elements_total.go
@@ -1,0 +1,48 @@
+
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv // TODO(bwplotka): Use id prefix or something more unique?
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+func MustNewSomeElementsCounterVec(reg prometheus.Registerer) *prometheus.CounterVec {
+	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "my_app_some_elements_total",
+		Help: "old metric",
+		// Unit: "unknown" // TODO(bwplotka): Add Unit as one of the supported options.
+	}, []string{
+	})
+}
+
+/*
+TODO(bwplotka): Add more type safety e.g. for CustomElementsCounterVec:
+
+type CustomElementsCounterVec struct {
+	prometheus.CounterVec
+}
+
+func (v *CustomElementsCounterVec) WithLabelValues(integer int, category CustomElementsCategory, fraction float64) prometheus.Counter {
+	// This is not ideal as we do, potentially expensive stringifying on the hot path.
+  // Fix might require internals to completely differ in the client_golang for the efficient solution.
+	return v.CounterVec.WithLabelValues(fmt.Sprintf("%v", integer), string(category), fmt.Sprintf("%v", fraction))
+}
+*/
+
+
+

--- a/my-org/semconv/v0.1.0/my-app.yaml
+++ b/my-org/semconv/v0.1.0/my-app.yaml
@@ -1,0 +1,48 @@
+# Schema: https://github.com/open-telemetry/weaver/blob/main/schemas/semconv.schema.json
+groups:
+- id: metric.my-org.custom_elements
+  type: metric
+  metric_name: my_app_custom_elements_total
+  brief: "Custom counter metric for my app counting important elements. It serves as an example of a very important metric that everyone is using."
+  instrument: counter
+  # Unit schema: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#instrument-units
+  # It comes from https://unitsofmeasure.org/ucum standard.
+  unit: "elements"
+  attributes:
+  - id: metric.my-org.custom_elements.integer
+    tag: "integer"
+    type: int
+    requirement_level: required
+    brief: |
+      This is an important label that specifies the integer for this count.
+  - id: metric.my-org.custom_elements.category
+    tag: "category"
+    type:
+      members:
+      - id: a
+        value: "a"
+        stability: stable
+      - id: b
+        value: "b"
+        stability: stable
+      - id: other
+        value: "other"
+        stability: stable
+    requirement_level: required
+    brief: |
+      This is an important label that specifies the category for this count.
+  - id: metric.my-org.custom_elements.fraction
+    tag: "fraction"
+    type: double
+    requirement_level: recommended
+    brief: |
+      This is an important label that specifies the fraction for this count.
+  stability: stable
+- id: metric.my-org.some_elements
+  type: metric
+  metric_name: my_app_some_elements_total
+  deprecated: "Deprecated, not needed anymore"
+  brief: "old metric"
+  instrument: counter
+  unit: "unknown"
+  stability: experimental

--- a/my-org/semconv/v0.1.0/my-app.yaml
+++ b/my-org/semconv/v0.1.0/my-app.yaml
@@ -7,12 +7,11 @@ groups:
   instrument: counter
   # Unit schema: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#instrument-units
   # It comes from https://unitsofmeasure.org/ucum standard.
-  unit: "elements"
+  unit: "{elements}"
   attributes:
   - id: metric.my-org.custom_elements.integer
     tag: "integer"
     type: int
-    requirement_level: required
     brief: |
       This is an important label that specifies the integer for this count.
   - id: metric.my-org.custom_elements.category
@@ -28,13 +27,11 @@ groups:
       - id: other
         value: "other"
         stability: stable
-    requirement_level: required
     brief: |
       This is an important label that specifies the category for this count.
   - id: metric.my-org.custom_elements.fraction
     tag: "fraction"
     type: double
-    requirement_level: recommended
     brief: |
       This is an important label that specifies the fraction for this count.
   stability: stable
@@ -44,5 +41,5 @@ groups:
   deprecated: "Deprecated, not needed anymore"
   brief: "old metric"
   instrument: counter
-  unit: "unknown"
+  unit: "{unknown}"
   stability: experimental


### PR DESCRIPTION
First iteration of the use of [weaver](https://github.com/open-telemetry/weaver) to define and generate Prometheus SDK metrics in Go.

It was surprisingly fast and simple to developo, kudos to Otel community for this 💪🏽 Took mi ~2.5h to craft this. The weaver tool is ultra fast, with super helpful diagnostics and errors, super useful (I used not even prod optimized version).

Generally [this forge doc](https://github.com/open-telemetry/weaver/blob/main/crates/weaver_forge/README.md#jq-filters-reference) was a good place to start for me. Some initial list of things to potentially improve/contribute to weaver/semconv:

* Documentation
  * It was like 10y+ since I develop j2 templates, some good docs would be nice to link. I was using bunch of different resources e.g. [1](https://ttl255.com/jinja2-tutorial-part-2-loops-and-conditionals/), [2](https://jinja.palletsprojects.com/en/stable/templates).
  * I spent some time looking on internet where the `kebab_case` function comes from and what are other functions like this. Turns out those are defined in weaver, ideally we link to [this](https://github.com/open-telemetry/weaver/blob/e9e53503cb67d8cf186e7a48d4c7b1bf93d6a9f6/crates/weaver_forge/src/extensions/case.rs#L72) file or so.
  * I eventually found it, and it's linked somewhere, but semconv schema should be on the top of docs [json](https://github.com/open-telemetry/weaver/blob/main/schemas/semconv.schema.json), [md more concise](https://github.com/open-telemetry/weaver/blob/main/schemas/semconv-syntax.md).
  * More accessible link to weaver YAML schema ([link](https://github.com/open-telemetry/weaver/blob/main/docs/weaver-config.md).
  * The filter parameter is quite confusing at the start. Perhaps it's worth to at least document what's the behaviour without filter or simple filter e.g. `groups.` (the fact that you have `ctx` variable with `each` setting).
* Semconv schema  
  * IDs and references
    * For code generation it's often desired to know "namespace" and shortest, ID for each metric/attributes. In example I see many different styles for ID format. There might be problem where some generators/templates will simply assume certain format e.g. in my example I take only last part of ID after `.` for metric identification. For namespace (e.g. for unique Go package name) I would take something that will give me `my-app` from somewhere. There's a little bit of chaos here, not sure what would help - maybe explicit `namespace` and `short_name` for metrics and labels? The prefixed attribute names in the official Otel semconv does not help here 🙈  Another solution would be to have some weaver j2 helper functions for that.
     * Generated code is generally oververbose and have long constructs (for Go that's not idiomatic). Anything that will make it shorter would help. 
  * Still not clear why some values of `unit` is inside curly brackets e.g.  "{goroutine}" and some are strings like “By”.
  *  Requirement levels are overwhelming. Why using semantic version for registries if we have to set requirement for every single element (including label names and label values(?))?
  * Use with Prometheus metrics
     * It's actually doable, but ofc you have to understand that `attribute` is simply `label` and `instrument` is a metric type. Definitely ok for the first pass, but perhaps there's some room for simplified schema that generate Otel semconv schema 🙈 

Next steps for our demo/work @vesari 
* Make it more type safe (see todos in the code)
* Play with diff, rename strategies.  
